### PR TITLE
Dockerize rooms-frontend

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM nginx:stable-alpine
+WORKDIR /app
+
+COPY dist /usr/share/nginx/html
+
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ npm run build:production
 - To add to the `go-ssb-room` repo:
   - Copy the `index.html` and all `assets` from the `dist/` folder to `go-ssb-room/web/assets`
 
+### Building a Docker image
+
+Another option for prepping for production is to build a new docker image, then push this to your docker repository.
+There is a minimal Dockerfile in this repo to help.  At the moment, the flow is to build the app first, and then
+run the docker build to create an image with your static compiled files served up from an nginx container.
+
 ### Staging
 
 ```sh


### PR DESCRIPTION
This PR adds a Dockerfile for serving a build rooms frontend from an nginx docker image, for easier compatibility with ansible scripts.

Importantly, the docker image does not build the vue app largely cos I was having difficulty with the memory usage the build step requires and having that happen consistently inside docker.    So the best use would be to build the production distribution on a beefy machine and then run the docker build scripts after the `dist` folder is created.

If this flow works, I can add a PR to the wiki explaining the docker build step in more detail.

There is an example docker image of this built and available as zachboyofdestiny/rooms-frontend:1.2