### PR TITLE
New dockerfile that better automates build

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,4 +1,4 @@
 NODE_ENV=production
-VITE_GRAPHQL_API=https://graphql.planetary.pub
-VITE_BLOB_URL=https://graphql.planetary.pub/blob
+VITE_GRAPHQL_API=/graphql/
+VITE_BLOB_URL=/blob
 VITE_BASE_DIR=/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,22 @@
-FROM nginx:stable-alpine
+FROM node:16-bullseye as build-stage
+RUN apt-get update
+RUN  apt-get install -y \
+  python \
+  build-essential \
+  libcairo2-dev \
+  libpango1.0-dev \
+  libjpeg-dev \
+  libgif-dev \
+  librsvg2-dev
+
 WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY . .
+RUN npm run build:production
 
-COPY dist /usr/share/nginx/html
-
+# production stage
+FROM nginx:stable-alpine as production-stage
+COPY --from=build-stage /app/dist /usr/share/nginx/html
 EXPOSE 80
-
 CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
previously, we were building the app and then copying the resulting dist folder into our docker image.  By adjusting the base image and ensuring it has everything necessary to build our app, we can do it all as part of the docker image building process.  This sets us up to more easily create frontend images as part of an automated pipeline.

This PR also adjusts the committed .env.production file.   our production single-host setup uses an nginx proxy to direct traffic to the appropriate services. This means that the frontend does not need to have a separate url to talk to the graphql or blob servers, and can just put in a local path.   Since this file is not giving any secrets, and is
already committed, we can change it to better fit the new setup.